### PR TITLE
Update gradle & limit repositories for internal packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,14 @@
 buildscript {
     repositories {
-        mavenCentral()
-        google()
-        jcenter()
+        mavenCentral {
+            content { excludeGroupByRegex "fi\\.vm\\.yti.*" }
+        }
+        google {
+            content { excludeGroupByRegex "fi\\.vm\\.yti.*" }
+        }
+        jcenter {
+            content { excludeGroupByRegex "fi\\.vm\\.yti.*" }
+        }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.1.RELEASE")
@@ -42,9 +48,16 @@ task sourceJar(type: Jar) {
 
 repositories {
     mavenLocal()
-    mavenCentral()
-    google()
-    jcenter()
+    mavenCentral {
+        content { excludeGroupByRegex "fi\\.vm\\.yti.*" }
+    }
+    google {
+        content { excludeGroupByRegex "fi\\.vm\\.yti.*" }
+    }
+    jcenter {
+        content { excludeGroupByRegex "fi\\.vm\\.yti.*" }
+    }
+
     // put your artifactory parameters to $HOME/.gradle/gradle.properties
     if (project.hasProperty('artifactoryUrl')) {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ dependencies {
 springBoot {
     executable = true
     backupSource = false
+    mainClass = 'fi.vm.yti.mq.service.YtiMQService.java'
 }
 
 bootRun {
@@ -122,7 +123,6 @@ bootRun {
 }
 
 bootRepackage {
-    mainClass = 'fi.vm.yti.mq.Application'
 }
 
 sonarqube {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Packages in the `fi.vm.yti` namespace should never be downloaded from public repos. To enforce this, the `excludeGroupByRegex` option found in newer gradle versions can be used.

This pull request:
* Updates gradle version
* Fix build error by specifying `springBoot.mainClass`
* Adds exclude options to repositories in `build.gradle`

After these changes the gradle build still complains about some deprecated configuration, but I've decided not to fix it in this PR.

Output before adding excludes:
```
Resource missing. [HTTP GET: https://repo.maven.apache.org/maven2/fi/vm/yti/yti-spring-security/0.1.8/yti-spring-security-0.1.8.pom]
Resource missing. [HTTP GET: https://dl.google.com/dl/android/maven2/fi/vm/yti/yti-spring-security/0.1.8/yti-spring-security-0.1.8.pom]
Resource missing. [HTTP GET: https://jcenter.bintray.com/fi/vm/yti/yti-spring-security/0.1.8/yti-spring-security-0.1.8.pom]
```